### PR TITLE
use c function

### DIFF
--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -9,24 +9,6 @@
 import Foundation
 
 enum CFunctionInjector {
-    // Ref: https://academy.realm.io/jp/posts/sash-zats-swift-swizzling/
-    private struct swift_func_wrapper {
-        var trampoline_ptr: UnsafeMutablePointer<uintptr_t>
-        var function_object: UnsafeMutablePointer<swift_func_object>
-        
-        var c_function_pointer: UnsafeMutableRawPointer? {
-            return UnsafeMutableRawPointer(bitPattern: function_object.pointee.address)
-        }
-    }
-    
-    // Ref: https://academy.realm.io/jp/posts/sash-zats-swift-swizzling/
-    private struct swift_func_object {
-        var original_type_ptr: UnsafeMutablePointer<uintptr_t>
-        var unknown: UnsafeMutablePointer<UInt64>
-        var address: uintptr_t
-        var selfPtr: UnsafeMutablePointer<uintptr_t>
-    }
-    
     private static var injected_functions: [Int: __int64_t] = [:]
     private static func assert_function_not_injected(_ origin: UnsafeMutablePointer<__int64_t>) {
         assert(!injected_functions.keys.contains(Int(bitPattern: origin)))
@@ -40,14 +22,14 @@ enum CFunctionInjector {
         origin.pointee = original_offset
     }
     
-    /// Inject swift function to c function.
+    /// Inject c function to c function.
     /// Objective-C bridging is not work in injected function.
     /// The injected functions argument and return value should use original type or `UnsafeRawPointer`.
     /// Ref: https://github.com/thomasfinch/CRuntimeFunctionHooker/blob/master/inject.c
     ///
     /// - Parameters:
     ///   - symbol: c function name.
-    ///   - target: function pointer. should use `withUnsafePointer(to:_:)`.
+    ///   - target: c function pointer.`.
     static func inject(_ symbol: UnsafePointer<Int8>!, _ target: UnsafeRawPointer) {
         assert(Thread.isMainThread)
         
@@ -62,9 +44,6 @@ enum CFunctionInjector {
         let pageStart = start & -pageSize
         mprotect(UnsafeMutableRawPointer(bitPattern: pageStart), end - pageStart, PROT_READ | PROT_WRITE | PROT_EXEC)
 
-        // get actual c function target from swift function
-        let target = target.assumingMemoryBound(to: swift_func_wrapper.self).pointee.c_function_pointer
-        
         // Calculate the relative offset needed for the jump instruction.
         // Since relative jumps are calculated from the address of the next instruction,
         // 5 bytes must be added to the original address (jump instruction is 5 bytes).


### PR DESCRIPTION
## c関数

convention(c)を使ってC関数をSwiftコードから構築すると、
Swift関数からC関数に変換してる工程が不要になります

いずれにせよcontextのあるSwift関数だと動かないため、
Swift関数のinjectは事実上できていないので、これが適切と思います

また、convention(c)だと、C互換でない型が関数の引数にあるとコンパイルエラーになってくれるメリットもあります

## withUnsafePointerについて

withUnsafePointerは、クロージャの中で受け取ったポインタは、
クロージャが終わった時点で無効になっているという規約なので、
不適切です

https://developer.apple.com/documentation/swift/2431879-withunsafepointer
> The pointer argument to body is valid only during the execution of withUnsafePointer(to:_:). Do not store or return the pointer for later use.

今回のような、「その期間を超えて大丈夫だとわかっている」
ときに使うのは `unsafeBitCast`です。