### PR TITLE
Swift的によい型を使う

### DIFF
--- a/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
+++ b/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
@@ -36,7 +36,7 @@ class AssertAutolayoutContext {
     
     init(assert: @escaping (String, StaticString, UInt) -> (), file: StaticString, line: UInt) {
         _ = _initializeHook
-    
+        
         _assert = { assert($0, file, line) }
         _catchAutolayoutError = { _, allConstraints in
             self.errorViews += allConstraints


### PR DESCRIPTION
injected_functionsは、
keyが書き換えを行う命令のあるアドレス
valueが書き込んだ命令なので、
前者を`UnsafeMutableRawPointer`, 後者を`Int64`にしました

ちなみにポインタはそのままHashableとして使えます

相対アドレスを計算するところはIntにしました
SwiftのIntは「そのアーキテクチャのポインタと同じビット幅の整数」なので、
C言語でいうところの`intptr_t`です。
なのでアドレスの加減算に対して適切なビット幅です

アドレスの型を `UnsafeMutablePointer<Int64>`にする選択肢は微妙だと思いました。

ポインタの参照先の型が問題になるのは、
実際に64bitの命令バイトを読み書きする場面だけです。

そして微妙なのが 0xE9 = JMP rel32 は 5バイト=40ビットの命令列っぽいです。
https://c9x.me/x86/html/file_module_x86_id_147.html

つまりここで64bitで扱ってるのはそうやって書き込みたいだけで、
型的な意味はなさそうです。

RTLD_DEFAULTは`fnctl.h`で定義されてる定数なのでグローバルに定義して共通化してみました。
`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dlfcn.h`
で確認できます。
`#define` で書かれているためにSwiftにimportできてないみたいです。

symbolはString型にしました。
dlsymで使うところで自動的にC文字列にしてくれるので。