### PR TITLE
C言語でのexternを使って、より安全にする

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "XCTAssertAutolayout",
+    platforms: [
+        .iOS(.v9),
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -19,8 +22,11 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
-            name: "XCTAssertAutolayout",
+            name: "CXCTAssertAutolayout",
             dependencies: []),
+        .target(
+            name: "XCTAssertAutolayout",
+            dependencies: ["CXCTAssertAutolayout"]),
         .testTarget(
             name: "XCTAssertAutolayoutTests",
             dependencies: ["XCTAssertAutolayout"]),

--- a/Sources/CXCTAssertAutolayout/dummy.m
+++ b/Sources/CXCTAssertAutolayout/dummy.m
@@ -1,0 +1,1 @@
+void CXCTAssertAutolayoutDummy(void) {}

--- a/Sources/CXCTAssertAutolayout/include/CXCTAssertAutolayout.h
+++ b/Sources/CXCTAssertAutolayout/include/CXCTAssertAutolayout.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+extern void UIViewAlertForUnsatisfiableConstraints(NSLayoutConstraint  * __nonnull constraint,
+                                                   NSArray<NSLayoutConstraint *> * __nonnull allConstraints);

--- a/XCTAssertAutolayout.xcodeproj/CXCTAssertAutolayout_Info.plist
+++ b/XCTAssertAutolayout.xcodeproj/CXCTAssertAutolayout_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/XCTAssertAutolayout.xcodeproj/project.pbxproj
+++ b/XCTAssertAutolayout.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXAggregateTarget section */
 		"XCTAssertAutolayout::XCTAssertAutolayoutPackageTests::ProductTarget" /* XCTAssertAutolayoutPackageTests */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_38 /* Build configuration list for PBXAggregateTarget "XCTAssertAutolayoutPackageTests" */;
+			buildConfigurationList = OBJ_62 /* Build configuration list for PBXAggregateTarget "XCTAssertAutolayoutPackageTests" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_41 /* PBXTargetDependency */,
+				OBJ_65 /* PBXTargetDependency */,
 			);
 			name = XCTAssertAutolayoutPackageTests;
 			productName = XCTAssertAutolayoutPackageTests;
@@ -21,226 +21,233 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		D22D5D4022940EAD00A3A402 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D22D5D3F22940EAD00A3A402 /* UIKit.framework */; };
-		D22D5D4422940EBA00A3A402 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D22D5D4322940EBA00A3A402 /* XCTest.framework */; };
-		D22D5D7B22950FDE00A3A402 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22D5D7A22950FDE00A3A402 /* AppDelegate.swift */; };
-		D22D5D7D22950FDE00A3A402 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22D5D7C22950FDE00A3A402 /* ViewController.swift */; };
-		D22D5D8022950FDE00A3A402 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D22D5D7E22950FDE00A3A402 /* Main.storyboard */; };
-		D22D5D8222950FE000A3A402 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22D5D8122950FE000A3A402 /* Assets.xcassets */; };
-		D22D5D8522950FE000A3A402 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D22D5D8322950FE000A3A402 /* LaunchScreen.storyboard */; };
-		D22D5D8D229518F600A3A402 /* AssertAutolayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22D5D8C229518F600A3A402 /* AssertAutolayoutContext.swift */; };
-		D22D5D8F2295191B00A3A402 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22D5D8E2295191B00A3A402 /* Node.swift */; };
-		OBJ_27 /* CFunctionInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* CFunctionInjector.swift */; };
-		OBJ_28 /* Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Core.swift */; };
-		OBJ_29 /* AssertAutolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* AssertAutolayout.swift */; };
-		OBJ_36 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_47 /* XCTAssertAutolayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* XCTAssertAutolayoutTests.swift */; };
-		OBJ_48 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* XCTestManifests.swift */; };
-		OBJ_50 /* XCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */; };
+		OBJ_38 /* dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* dummy.m */; };
+		OBJ_40 /* CXCTAssertAutolayout.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CXCTAssertAutolayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_47 /* AssertAutolayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* AssertAutolayoutContext.swift */; };
+		OBJ_48 /* CFunctionInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* CFunctionInjector.swift */; };
+		OBJ_49 /* Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* Core.swift */; };
+		OBJ_50 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Node.swift */; };
+		OBJ_51 /* AssertAutolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* AssertAutolayout.swift */; };
+		OBJ_53 /* CXCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCTAssertAutolayout::CXCTAssertAutolayout::Product" /* CXCTAssertAutolayout.framework */; };
+		OBJ_60 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_71 /* XCTAssertAutolayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* XCTAssertAutolayoutTests.swift */; };
+		OBJ_72 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* XCTestManifests.swift */; };
+		OBJ_74 /* XCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */; };
+		OBJ_75 /* CXCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "XCTAssertAutolayout::CXCTAssertAutolayout::Product" /* CXCTAssertAutolayout.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		D22D5D3C22940E3200A3A402 /* PBXContainerItemProxy */ = {
+		D62F65462296526C00175D64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "XCTAssertAutolayout::CXCTAssertAutolayout";
+			remoteInfo = CXCTAssertAutolayout;
+		};
+		D62F65472296526C00175D64 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "XCTAssertAutolayout::XCTAssertAutolayout";
 			remoteInfo = XCTAssertAutolayout;
 		};
-		D22D5D3D22940E3500A3A402 /* PBXContainerItemProxy */ = {
+		D62F65482296526C00175D64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "XCTAssertAutolayout::CXCTAssertAutolayout";
+			remoteInfo = CXCTAssertAutolayout;
+		};
+		D62F65492296526D00175D64 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "XCTAssertAutolayout::XCTAssertAutolayoutTests";
 			remoteInfo = XCTAssertAutolayoutTests;
 		};
-		D22D5D8A22950FED00A3A402 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D22D5D7722950FDE00A3A402;
-			remoteInfo = XCTAssertAutolayoutTestApp;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		D22D5D3F22940EAD00A3A402 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		D22D5D4122940EB200A3A402 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		D22D5D4322940EBA00A3A402 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		D22D5D7822950FDE00A3A402 /* XCTAssertAutolayoutTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XCTAssertAutolayoutTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D22D5D7A22950FDE00A3A402 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		D22D5D7C22950FDE00A3A402 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		D22D5D7F22950FDE00A3A402 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		D22D5D8122950FE000A3A402 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D22D5D8422950FE000A3A402 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		D22D5D8622950FE000A3A402 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D22D5D8C229518F600A3A402 /* AssertAutolayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertAutolayoutContext.swift; sourceTree = "<group>"; };
-		D22D5D8E2295191B00A3A402 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
-		OBJ_10 /* CFunctionInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CFunctionInjector.swift; sourceTree = "<group>"; };
-		OBJ_11 /* Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core.swift; sourceTree = "<group>"; };
-		OBJ_13 /* AssertAutolayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertAutolayout.swift; sourceTree = "<group>"; };
-		OBJ_16 /* XCTAssertAutolayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertAutolayoutTests.swift; sourceTree = "<group>"; };
-		OBJ_17 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_21 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_11 /* CXCTAssertAutolayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CXCTAssertAutolayout.h; sourceTree = "<group>"; };
+		OBJ_14 /* AssertAutolayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertAutolayoutContext.swift; sourceTree = "<group>"; };
+		OBJ_15 /* CFunctionInjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CFunctionInjector.swift; sourceTree = "<group>"; };
+		OBJ_16 /* Core.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core.swift; sourceTree = "<group>"; };
+		OBJ_17 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		OBJ_19 /* AssertAutolayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertAutolayout.swift; sourceTree = "<group>"; };
+		OBJ_22 /* XCTAssertAutolayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertAutolayoutTests.swift; sourceTree = "<group>"; };
+		OBJ_23 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_28 /* XCTAssertAutolayout.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = XCTAssertAutolayout.xcworkspace; sourceTree = SOURCE_ROOT; };
+		OBJ_29 /* Readme */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Readme; sourceTree = SOURCE_ROOT; };
+		OBJ_32 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		"XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = XCTAssertAutolayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"XCTAssertAutolayout::XCTAssertAutolayoutTests::Product" /* XCTAssertAutolayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = XCTAssertAutolayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_9 /* dummy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = dummy.m; sourceTree = "<group>"; };
+		"XCTAssertAutolayout::CXCTAssertAutolayout::Product" /* CXCTAssertAutolayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CXCTAssertAutolayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCTAssertAutolayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"XCTAssertAutolayout::XCTAssertAutolayoutTests::Product" /* XCTAssertAutolayoutTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = XCTAssertAutolayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		D22D5D7522950FDE00A3A402 /* Frameworks */ = {
+		OBJ_41 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_30 /* Frameworks */ = {
+		OBJ_52 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				D22D5D4422940EBA00A3A402 /* XCTest.framework in Frameworks */,
-				D22D5D4022940EAD00A3A402 /* UIKit.framework in Frameworks */,
+				OBJ_53 /* CXCTAssertAutolayout.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_49 /* Frameworks */ = {
+		OBJ_73 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_50 /* XCTAssertAutolayout.framework in Frameworks */,
+				OBJ_74 /* XCTAssertAutolayout.framework in Frameworks */,
+				OBJ_75 /* CXCTAssertAutolayout.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		D22D5D3E22940EAD00A3A402 /* Frameworks */ = {
+		OBJ_10 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				D22D5D4122940EB200A3A402 /* XCTest.framework */,
-				D22D5D4322940EBA00A3A402 /* XCTest.framework */,
-				D22D5D3F22940EAD00A3A402 /* UIKit.framework */,
+				OBJ_11 /* CXCTAssertAutolayout.h */,
 			);
-			name = Frameworks;
+			path = include;
 			sourceTree = "<group>";
 		};
-		D22D5D7922950FDE00A3A402 /* XCTAssertAutolayoutTestApp */ = {
+		OBJ_12 /* XCTAssertAutolayout */ = {
 			isa = PBXGroup;
 			children = (
-				D22D5D7A22950FDE00A3A402 /* AppDelegate.swift */,
-				D22D5D7C22950FDE00A3A402 /* ViewController.swift */,
-				D22D5D7E22950FDE00A3A402 /* Main.storyboard */,
-				D22D5D8122950FE000A3A402 /* Assets.xcassets */,
-				D22D5D8322950FE000A3A402 /* LaunchScreen.storyboard */,
-				D22D5D8622950FE000A3A402 /* Info.plist */,
-			);
-			path = XCTAssertAutolayoutTestApp;
-			sourceTree = "<group>";
-		};
-		OBJ_12 /* Front */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_13 /* AssertAutolayout.swift */,
-			);
-			path = Front;
-			sourceTree = "<group>";
-		};
-		OBJ_14 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_15 /* XCTAssertAutolayoutTests */,
-				D22D5D7922950FDE00A3A402 /* XCTAssertAutolayoutTestApp */,
-			);
-			name = Tests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_15 /* XCTAssertAutolayoutTests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_16 /* XCTAssertAutolayoutTests.swift */,
-				OBJ_17 /* XCTestManifests.swift */,
-			);
-			name = XCTAssertAutolayoutTests;
-			path = Tests/XCTAssertAutolayoutTests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_18 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				"XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */,
-				"XCTAssertAutolayout::XCTAssertAutolayoutTests::Product" /* XCTAssertAutolayoutTests.xctest */,
-				D22D5D7822950FDE00A3A402 /* XCTAssertAutolayoutTestApp.app */,
-			);
-			name = Products;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_5 = {
-			isa = PBXGroup;
-			children = (
-				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Sources */,
-				OBJ_14 /* Tests */,
-				OBJ_18 /* Products */,
-				OBJ_21 /* README.md */,
-				D22D5D3E22940EAD00A3A402 /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		OBJ_7 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_8 /* XCTAssertAutolayout */,
-			);
-			name = Sources;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_8 /* XCTAssertAutolayout */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_9 /* Core */,
-				OBJ_12 /* Front */,
+				OBJ_13 /* Core */,
+				OBJ_18 /* Front */,
 			);
 			name = XCTAssertAutolayout;
 			path = Sources/XCTAssertAutolayout;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_9 /* Core */ = {
+		OBJ_13 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_10 /* CFunctionInjector.swift */,
-				D22D5D8E2295191B00A3A402 /* Node.swift */,
-				D22D5D8C229518F600A3A402 /* AssertAutolayoutContext.swift */,
-				OBJ_11 /* Core.swift */,
+				OBJ_14 /* AssertAutolayoutContext.swift */,
+				OBJ_15 /* CFunctionInjector.swift */,
+				OBJ_16 /* Core.swift */,
+				OBJ_17 /* Node.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
 		};
+		OBJ_18 /* Front */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_19 /* AssertAutolayout.swift */,
+			);
+			path = Front;
+			sourceTree = "<group>";
+		};
+		OBJ_20 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_21 /* XCTAssertAutolayoutTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_21 /* XCTAssertAutolayoutTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_22 /* XCTAssertAutolayoutTests.swift */,
+				OBJ_23 /* XCTestManifests.swift */,
+			);
+			name = XCTAssertAutolayoutTests;
+			path = Tests/XCTAssertAutolayoutTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_24 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"XCTAssertAutolayout::CXCTAssertAutolayout::Product" /* CXCTAssertAutolayout.framework */,
+				"XCTAssertAutolayout::XCTAssertAutolayout::Product" /* XCTAssertAutolayout.framework */,
+				"XCTAssertAutolayout::XCTAssertAutolayoutTests::Product" /* XCTAssertAutolayoutTests.xctest */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_20 /* Tests */,
+				OBJ_24 /* Products */,
+				OBJ_28 /* XCTAssertAutolayout.xcworkspace */,
+				OBJ_29 /* Readme */,
+				OBJ_32 /* README.md */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* CXCTAssertAutolayout */,
+				OBJ_12 /* XCTAssertAutolayout */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* CXCTAssertAutolayout */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* dummy.m */,
+				OBJ_10 /* include */,
+			);
+			name = CXCTAssertAutolayout;
+			path = Sources/CXCTAssertAutolayout;
+			sourceTree = SOURCE_ROOT;
+		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		OBJ_39 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_40 /* CXCTAssertAutolayout.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		D22D5D7722950FDE00A3A402 /* XCTAssertAutolayoutTestApp */ = {
+		"XCTAssertAutolayout::CXCTAssertAutolayout" /* CXCTAssertAutolayout */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D22D5D8722950FE000A3A402 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTestApp" */;
+			buildConfigurationList = OBJ_34 /* Build configuration list for PBXNativeTarget "CXCTAssertAutolayout" */;
 			buildPhases = (
-				D22D5D7422950FDE00A3A402 /* Sources */,
-				D22D5D7522950FDE00A3A402 /* Frameworks */,
-				D22D5D7622950FDE00A3A402 /* Resources */,
+				OBJ_37 /* Sources */,
+				OBJ_39 /* Headers */,
+				OBJ_41 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = XCTAssertAutolayoutTestApp;
-			productName = XCTAssertAutolayoutTestApp;
-			productReference = D22D5D7822950FDE00A3A402 /* XCTAssertAutolayoutTestApp.app */;
-			productType = "com.apple.product-type.application";
+			name = CXCTAssertAutolayout;
+			productName = CXCTAssertAutolayout;
+			productReference = "XCTAssertAutolayout::CXCTAssertAutolayout::Product" /* CXCTAssertAutolayout.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		"XCTAssertAutolayout::SwiftPMPackageDescription" /* XCTAssertAutolayoutPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_32 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutPackageDescription" */;
+			buildConfigurationList = OBJ_56 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutPackageDescription" */;
 			buildPhases = (
-				OBJ_35 /* Sources */,
+				OBJ_59 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -252,14 +259,15 @@
 		};
 		"XCTAssertAutolayout::XCTAssertAutolayout" /* XCTAssertAutolayout */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_23 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayout" */;
+			buildConfigurationList = OBJ_43 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayout" */;
 			buildPhases = (
-				OBJ_26 /* Sources */,
-				OBJ_30 /* Frameworks */,
+				OBJ_46 /* Sources */,
+				OBJ_52 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				OBJ_54 /* PBXTargetDependency */,
 			);
 			name = XCTAssertAutolayout;
 			productName = XCTAssertAutolayout;
@@ -268,16 +276,16 @@
 		};
 		"XCTAssertAutolayout::XCTAssertAutolayoutTests" /* XCTAssertAutolayoutTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_43 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTests" */;
+			buildConfigurationList = OBJ_67 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTests" */;
 			buildPhases = (
-				OBJ_46 /* Sources */,
-				OBJ_49 /* Frameworks */,
+				OBJ_70 /* Sources */,
+				OBJ_73 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_51 /* PBXTargetDependency */,
-				D22D5D8B22950FED00A3A402 /* PBXTargetDependency */,
+				OBJ_76 /* PBXTargetDependency */,
+				OBJ_77 /* PBXTargetDependency */,
 			);
 			name = XCTAssertAutolayoutTests;
 			productName = XCTAssertAutolayoutTests;
@@ -291,17 +299,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 9999;
-				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 9999;
-				TargetAttributes = {
-					D22D5D7722950FDE00A3A402 = {
-						CreatedOnToolsVersion = 10.2.1;
-						ProvisioningStyle = Automatic;
-					};
-					"XCTAssertAutolayout::XCTAssertAutolayoutTests" = {
-						TestTargetID = D22D5D7722950FDE00A3A402;
-					};
-				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "XCTAssertAutolayout" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -310,62 +308,27 @@
 			knownRegions = (
 				English,
 				en,
-				Base,
 			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_18 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_24 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				"XCTAssertAutolayout::CXCTAssertAutolayout" /* CXCTAssertAutolayout */,
 				"XCTAssertAutolayout::XCTAssertAutolayout" /* XCTAssertAutolayout */,
 				"XCTAssertAutolayout::SwiftPMPackageDescription" /* XCTAssertAutolayoutPackageDescription */,
 				"XCTAssertAutolayout::XCTAssertAutolayoutPackageTests::ProductTarget" /* XCTAssertAutolayoutPackageTests */,
 				"XCTAssertAutolayout::XCTAssertAutolayoutTests" /* XCTAssertAutolayoutTests */,
-				D22D5D7722950FDE00A3A402 /* XCTAssertAutolayoutTestApp */,
 			);
 		};
 /* End PBXProject section */
 
-/* Begin PBXResourcesBuildPhase section */
-		D22D5D7622950FDE00A3A402 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D22D5D8522950FE000A3A402 /* LaunchScreen.storyboard in Resources */,
-				D22D5D8222950FE000A3A402 /* Assets.xcassets in Resources */,
-				D22D5D8022950FDE00A3A402 /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
-		D22D5D7422950FDE00A3A402 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D22D5D7D22950FDE00A3A402 /* ViewController.swift in Sources */,
-				D22D5D7B22950FDE00A3A402 /* AppDelegate.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_26 /* Sources */ = {
+		OBJ_37 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_27 /* CFunctionInjector.swift in Sources */,
-				D22D5D8F2295191B00A3A402 /* Node.swift in Sources */,
-				OBJ_28 /* Core.swift in Sources */,
-				D22D5D8D229518F600A3A402 /* AssertAutolayoutContext.swift in Sources */,
-				OBJ_29 /* AssertAutolayout.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_35 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_36 /* Package.swift in Sources */,
+				OBJ_38 /* dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,219 +336,57 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_47 /* XCTAssertAutolayoutTests.swift in Sources */,
-				OBJ_48 /* XCTestManifests.swift in Sources */,
+				OBJ_47 /* AssertAutolayoutContext.swift in Sources */,
+				OBJ_48 /* CFunctionInjector.swift in Sources */,
+				OBJ_49 /* Core.swift in Sources */,
+				OBJ_50 /* Node.swift in Sources */,
+				OBJ_51 /* AssertAutolayout.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_59 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_60 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_70 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_71 /* XCTAssertAutolayoutTests.swift in Sources */,
+				OBJ_72 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		D22D5D8B22950FED00A3A402 /* PBXTargetDependency */ = {
+		OBJ_54 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = D22D5D7722950FDE00A3A402 /* XCTAssertAutolayoutTestApp */;
-			targetProxy = D22D5D8A22950FED00A3A402 /* PBXContainerItemProxy */;
+			target = "XCTAssertAutolayout::CXCTAssertAutolayout" /* CXCTAssertAutolayout */;
+			targetProxy = D62F65462296526C00175D64 /* PBXContainerItemProxy */;
 		};
-		OBJ_41 /* PBXTargetDependency */ = {
+		OBJ_65 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "XCTAssertAutolayout::XCTAssertAutolayoutTests" /* XCTAssertAutolayoutTests */;
-			targetProxy = D22D5D3D22940E3500A3A402 /* PBXContainerItemProxy */;
+			targetProxy = D62F65492296526D00175D64 /* PBXContainerItemProxy */;
 		};
-		OBJ_51 /* PBXTargetDependency */ = {
+		OBJ_76 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "XCTAssertAutolayout::XCTAssertAutolayout" /* XCTAssertAutolayout */;
-			targetProxy = D22D5D3C22940E3200A3A402 /* PBXContainerItemProxy */;
+			targetProxy = D62F65472296526C00175D64 /* PBXContainerItemProxy */;
+		};
+		OBJ_77 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "XCTAssertAutolayout::CXCTAssertAutolayout" /* CXCTAssertAutolayout */;
+			targetProxy = D62F65482296526C00175D64 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
-/* Begin PBXVariantGroup section */
-		D22D5D7E22950FDE00A3A402 /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				D22D5D7F22950FDE00A3A402 /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
-		D22D5D8322950FE000A3A402 /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				D22D5D8422950FE000A3A402 /* Base */,
-			);
-			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
 /* Begin XCBuildConfiguration section */
-		D22D5D8822950FE000A3A402 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = XCTAssertAutolayoutTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tarunon.XCTAssertAutolayoutTestApp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		D22D5D8922950FE000A3A402 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				COPY_PHASE_STRIP = NO;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = XCTAssertAutolayoutTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tarunon.XCTAssertAutolayoutTestApp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		OBJ_24 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayout_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCTAssertAutolayout;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCTAssertAutolayout;
-			};
-			name = Debug;
-		};
-		OBJ_25 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayout_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = XCTAssertAutolayout;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCTAssertAutolayout;
-			};
-			name = Release;
-		};
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -601,41 +402,81 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
-		OBJ_33 /* Debug */ = {
+		OBJ_35 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 5.0;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
+				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/CXCTAssertAutolayout_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CXCTAssertAutolayout;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = CXCTAssertAutolayout;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
-		OBJ_34 /* Release */ = {
+		OBJ_36 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 5.0;
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
+				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/CXCTAssertAutolayout_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = CXCTAssertAutolayout;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				TARGET_NAME = CXCTAssertAutolayout;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
-		};
-		OBJ_39 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
 		};
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -650,79 +491,168 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
-		OBJ_40 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
 		OBJ_44 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayoutTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
+				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayout_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = XCTAssertAutolayout;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
-				TARGET_NAME = XCTAssertAutolayoutTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XCTAssertAutolayoutTestApp.app/XCTAssertAutolayoutTestApp";
+				TARGET_NAME = XCTAssertAutolayout;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
 		OBJ_45 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
+				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayout_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = XCTAssertAutolayout;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = XCTAssertAutolayout;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_57 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_58 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_63 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_64 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
 				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayoutTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = XCTAssertAutolayoutTests;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XCTAssertAutolayoutTestApp.app/XCTAssertAutolayoutTestApp";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_69 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Sources/CXCTAssertAutolayout/include",
+				);
+				INFOPLIST_FILE = XCTAssertAutolayout.xcodeproj/XCTAssertAutolayoutTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = XCTAssertAutolayoutTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D22D5D8722950FE000A3A402 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTestApp" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D22D5D8822950FE000A3A402 /* Debug */,
-				D22D5D8922950FE000A3A402 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		OBJ_2 /* Build configuration list for PBXProject "XCTAssertAutolayout" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -732,38 +662,47 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_23 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayout" */ = {
+		OBJ_34 /* Build configuration list for PBXNativeTarget "CXCTAssertAutolayout" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_24 /* Debug */,
-				OBJ_25 /* Release */,
+				OBJ_35 /* Debug */,
+				OBJ_36 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_32 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_33 /* Debug */,
-				OBJ_34 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_38 /* Build configuration list for PBXAggregateTarget "XCTAssertAutolayoutPackageTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_39 /* Debug */,
-				OBJ_40 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_43 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTests" */ = {
+		OBJ_43 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayout" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				OBJ_44 /* Debug */,
 				OBJ_45 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_56 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_57 /* Debug */,
+				OBJ_58 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_62 /* Build configuration list for PBXAggregateTarget "XCTAssertAutolayoutPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_63 /* Debug */,
+				OBJ_64 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_67 /* Build configuration list for PBXNativeTarget "XCTAssertAutolayoutTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_68 /* Debug */,
+				OBJ_69 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/XCTAssertAutolayout.xcodeproj/xcshareddata/xcschemes/XCTAssertAutolayout-Package.xcscheme
+++ b/XCTAssertAutolayout.xcodeproj/xcshareddata/xcschemes/XCTAssertAutolayout-Package.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayout"
+               BuildableName = "XCTAssertAutolayout.framework"
+               BlueprintName = "XCTAssertAutolayout"
+               ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTAssertAutolayout::CXCTAssertAutolayout"
+               BuildableName = "CXCTAssertAutolayout.framework"
+               BlueprintName = "CXCTAssertAutolayout"
+               ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayoutTests"
+               BuildableName = "XCTAssertAutolayoutTests.xctest"
+               BlueprintName = "XCTAssertAutolayoutTests"
+               ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayout"
+            BuildableName = "XCTAssertAutolayout.framework"
+            BlueprintName = "XCTAssertAutolayout"
+            ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/XCTAssertAutolayoutExample/XCTAssertAutolayoutExample.xcodeproj/project.pbxproj
+++ b/XCTAssertAutolayoutExample/XCTAssertAutolayoutExample.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		D22D5D5922940FE500A3A402 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D22D5D5822940FE500A3A402 /* Assets.xcassets */; };
 		D22D5D5C22940FE500A3A402 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D22D5D5A22940FE500A3A402 /* LaunchScreen.storyboard */; };
 		D22D5D6722940FE600A3A402 /* XCTAssertAutolayoutExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22D5D6622940FE600A3A402 /* XCTAssertAutolayoutExampleTests.swift */; };
-		D22D5D732294119C00A3A402 /* XCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D22D5D722294119C00A3A402 /* XCTAssertAutolayout.framework */; };
+		D62F65582296573100175D64 /* XCTAssertAutolayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D62F65572296573100175D64 /* XCTAssertAutolayout.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,7 +37,7 @@
 		D22D5D6222940FE600A3A402 /* XCTAssertAutolayoutExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCTAssertAutolayoutExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D22D5D6622940FE600A3A402 /* XCTAssertAutolayoutExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertAutolayoutExampleTests.swift; sourceTree = "<group>"; };
 		D22D5D6822940FE600A3A402 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D22D5D722294119C00A3A402 /* XCTAssertAutolayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = XCTAssertAutolayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D62F65572296573100175D64 /* XCTAssertAutolayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = XCTAssertAutolayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,7 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D22D5D732294119C00A3A402 /* XCTAssertAutolayout.framework in Frameworks */,
+				D62F65582296573100175D64 /* XCTAssertAutolayout.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,7 +103,7 @@
 		D22D5D712294119C00A3A402 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D22D5D722294119C00A3A402 /* XCTAssertAutolayout.framework */,
+				D62F65572296573100175D64 /* XCTAssertAutolayout.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -373,6 +373,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XCTAssertAutolayoutExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -390,6 +391,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XCTAssertAutolayoutExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -408,6 +410,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XCTAssertAutolayoutExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -428,6 +431,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XCTAssertAutolayoutExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/XCTAssertAutolayoutExample/XCTAssertAutolayoutExample.xcodeproj/xcshareddata/xcschemes/XCTAssertAutolayoutExample.xcscheme
+++ b/XCTAssertAutolayoutExample/XCTAssertAutolayoutExample.xcodeproj/xcshareddata/xcschemes/XCTAssertAutolayoutExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9999"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayout"
-               BuildableName = "XCTAssertAutolayout.framework"
-               BlueprintName = "XCTAssertAutolayout"
-               ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+               BlueprintIdentifier = "D22D5D4D22940FE300A3A402"
+               BuildableName = "XCTAssertAutolayoutExample.app"
+               BlueprintName = "XCTAssertAutolayoutExample"
+               ReferencedContainer = "container:XCTAssertAutolayoutExample.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -32,13 +32,22 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayoutTests"
-               BuildableName = "XCTAssertAutolayoutTests.xctest"
-               BlueprintName = "XCTAssertAutolayoutTests"
-               ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+               BlueprintIdentifier = "D22D5D6122940FE600A3A402"
+               BuildableName = "XCTAssertAutolayoutExampleTests.xctest"
+               BlueprintName = "XCTAssertAutolayoutExampleTests"
+               ReferencedContainer = "container:XCTAssertAutolayoutExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D22D5D4D22940FE300A3A402"
+            BuildableName = "XCTAssertAutolayoutExample.app"
+            BlueprintName = "XCTAssertAutolayoutExample"
+            ReferencedContainer = "container:XCTAssertAutolayoutExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -52,15 +61,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "XCTAssertAutolayout::XCTAssertAutolayout"
-            BuildableName = "XCTAssertAutolayout.framework"
-            BlueprintName = "XCTAssertAutolayout"
-            ReferencedContainer = "container:XCTAssertAutolayout.xcodeproj">
+            BlueprintIdentifier = "D22D5D4D22940FE300A3A402"
+            BuildableName = "XCTAssertAutolayoutExample.app"
+            BlueprintName = "XCTAssertAutolayoutExample"
+            ReferencedContainer = "container:XCTAssertAutolayoutExample.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -70,6 +80,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D22D5D4D22940FE300A3A402"
+            BuildableName = "XCTAssertAutolayoutExample.app"
+            BlueprintName = "XCTAssertAutolayoutExample"
+            ReferencedContainer = "container:XCTAssertAutolayoutExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
UIKitのAPIでターゲット警告が出てたのでPackage.swiftにiOS Versionの指定をしました。

C言語ターゲット`CXCTAssertAutolayout`を追加して、
UIKitのフック関数のヘッダをexternで手書きしました。

`dummy.c`はこれがないとSwiftPMが壊れるのでその対策です。

`$ swift package generate-xcodeproj` でプロジェクト生成して、
そのままExampleと連携可能になってます。

Swiftからオリジナルを呼び出すところでそれを呼び出すようにしました。
従来の実装だと、シンボル名を指定したSwift関数での宣言だったので、
Swift関数としてのシグネチャと実際のC関数のシグネチャが、
ABIレベルで同一である事の仮定が必要でした。
またそのため、NSArrayなどの指定が必要でした。

今回実際にC言語で宣言した上で、それをSwiftからC連携機能として認識させる事で、
Swiftから見た型として`Swift.Array<NSLayoutConstraint>`になりました。
内部的にはSwiftコンパイラが真のC関数の呼び出しを行うので、
ABI的に正当に結合できます。

これのおかげでSwift側の型が自然になって、
不要なcompactMapが削除できました。

`@convention(c)` になってるhook関数のシグネチャもSwiftに寄せてますが、
これもconvention cの恩恵で実際の関数はNSArrayになってます。

シンボル名を持った文字列の変数名が衝突するので変更しました。


