### PR TITLE
error handling

### DIFF
--- a/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
+++ b/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
@@ -19,7 +19,7 @@ let hookedUIViewAlertForUnsatisfiableConstraints: (@convention(c) (NSLayoutConst
     _catchAutolayoutError?(constraint, allConstraints)
     CFunctionInjector.reset(UIViewAlertForUnsatisfiableConstraintsSymbol)
     UIViewAlertForUnsatisfiableConstraints(constraint, allConstraints)
-    CFunctionInjector.inject(UIViewAlertForUnsatisfiableConstraintsSymbol, hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+    try! CFunctionInjector.inject(UIViewAlertForUnsatisfiableConstraintsSymbol, hookedUIViewAlertForUnsatisfiableConstraintsPointer)
 }
 
 class AssertAutolayoutContext {
@@ -37,7 +37,7 @@ class AssertAutolayoutContext {
         }
         
         hookedUIViewAlertForUnsatisfiableConstraintsPointer = unsafeBitCast(hookedUIViewAlertForUnsatisfiableConstraints, to: UnsafeRawPointer.self)
-        CFunctionInjector.inject(UIViewAlertForUnsatisfiableConstraintsSymbol, hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+        try! CFunctionInjector.inject(UIViewAlertForUnsatisfiableConstraintsSymbol, hookedUIViewAlertForUnsatisfiableConstraintsPointer)
     }
     
     func finalize() {


### PR DESCRIPTION
エラーハンドリングを追加しました。

`CFunctionInjector`の再利用性が向上すると思います。

`pop_injected_function`に関しては、
injectされている事は前提条件でいいと思います。
ユーザサイドのロジックで保証できますし。

`inject`はOSの何かしらの都合で失敗しうるので例外にしました。

これを使う `AssertAutolayoutContext` の側からすると、
例外を伝搬しても良い気もしますが、
`try!`にして既存の挙動を維持しました。
ただ初回呼び出しはともかく、hook内部での再度のinjectに関しては、
伝搬のしようもなさそうです。

エラー型に関してはとりあえずメッセージ文字列だけ実装しましたが、
将来的に、`errno`を`strerror`関数で文字列化する改善が考えられます。


