### PR TITLE
Support Apple Silicon

### DIFF
--- a/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
+++ b/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
@@ -18,9 +18,9 @@ var injector: CFunctionInjector?
 // make c function pointer by convention attribute
 let hookedUIViewAlertForUnsatisfiableConstraints: (@convention(c) (NSLayoutConstraint, [NSLayoutConstraint]) -> Void) = { (constraint: NSLayoutConstraint, allConstraints: [NSLayoutConstraint]) in
     _catchAutolayoutError?(constraint, allConstraints)
-    try! injector?.reset()
+    injector?.reset()
     UIViewAlertForUnsatisfiableConstraints(constraint, allConstraints)
-    try! injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+    injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
 }
 
 public class AssertAutolayoutContext {
@@ -72,13 +72,14 @@ class AssertAutolayoutContextInternal {
                 _assert("XCTAssertAutolayout should run in iPhoneSimulator, cannot run on real Devices. (\(error))", file, line)
             }
         }
+        
         hookedUIViewAlertForUnsatisfiableConstraintsPointer = unsafeBitCast(hookedUIViewAlertForUnsatisfiableConstraints, to: UnsafeRawPointer.self)
-        try! injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+        injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
     }
     
     func finalize() {
         _catchAutolayoutError = nil
-        try! injector?.reset()
+        injector?.reset()
     }
     
     private func getViewController(_ responder: UIResponder) -> UIViewController? {

--- a/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
+++ b/Sources/XCTAssertAutolayout/Core/AssertAutolayoutContext.swift
@@ -18,9 +18,9 @@ var injector: CFunctionInjector?
 // make c function pointer by convention attribute
 let hookedUIViewAlertForUnsatisfiableConstraints: (@convention(c) (NSLayoutConstraint, [NSLayoutConstraint]) -> Void) = { (constraint: NSLayoutConstraint, allConstraints: [NSLayoutConstraint]) in
     _catchAutolayoutError?(constraint, allConstraints)
-    injector?.reset()
+    try! injector?.reset()
     UIViewAlertForUnsatisfiableConstraints(constraint, allConstraints)
-    injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+    try! injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
 }
 
 public class AssertAutolayoutContext {
@@ -72,14 +72,13 @@ class AssertAutolayoutContextInternal {
                 _assert("XCTAssertAutolayout should run in iPhoneSimulator, cannot run on real Devices. (\(error))", file, line)
             }
         }
-        
         hookedUIViewAlertForUnsatisfiableConstraintsPointer = unsafeBitCast(hookedUIViewAlertForUnsatisfiableConstraints, to: UnsafeRawPointer.self)
-        injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
+        try! injector?.inject(hookedUIViewAlertForUnsatisfiableConstraintsPointer)
     }
     
     func finalize() {
         _catchAutolayoutError = nil
-        injector?.reset()
+        try! injector?.reset()
     }
     
     private func getViewController(_ responder: UIResponder) -> UIViewController? {

--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -16,12 +16,12 @@ class CFunctionInjector {
         var errorDescription: String? { return description }
     }
     
-    var originalFunctionPointer0: UnsafeMutablePointer<UInt64>
-    var originalFunctionPointer8: UnsafeMutablePointer<UInt64>
-    var originalFunctionPointer16: UnsafeMutablePointer<UInt64>
-    var escapedInstructionBytes0: UInt64
-    var escapedInstructionBytes8: UInt64
-    var escapedInstructionBytes16: UInt64
+    var originalFunctionPointer0: UnsafeMutablePointer<Int64>
+    var originalFunctionPointer8: UnsafeMutablePointer<Int64>
+    var originalFunctionPointer16: UnsafeMutablePointer<Int64>
+    var escapedInstructionBytes0: Int64
+    var escapedInstructionBytes8: Int64
+    var escapedInstructionBytes16: Int64
     let textRange: (start: UnsafeMutableRawPointer?, size: Int)
     
     /// Initialize CFunctionInjector object.
@@ -60,7 +60,7 @@ class CFunctionInjector {
         let pageStart = start & -pageSize
         let size = end - pageStart
         self.textRange = (UnsafeMutableRawPointer(bitPattern: pageStart), size)
-        self.originalFunctionPointer0 = target.assumingMemoryBound(to: UInt64.self)
+        self.originalFunctionPointer0 = target.assumingMemoryBound(to: Int64.self)
         self.escapedInstructionBytes0 = originalFunctionPointer0.pointee
         self.originalFunctionPointer8 = UnsafeMutablePointer(bitPattern: Int(bitPattern: target) + 8)!
         self.escapedInstructionBytes8 = originalFunctionPointer8.pointee
@@ -109,11 +109,11 @@ class CFunctionInjector {
             // 2. br x8
 
             originalFunctionPointer0.pointee =
-                (0xd2800008 | (UInt64(targetAddress & 0xffff) << 5)) |
-                (0xf2a00008 | UInt64(targetAddress >> 16 & 0xffff) << 5) << 32
+                (0xd2800008 | (Int64(targetAddress & 0xffff) << 5)) |
+                (0xf2a00008 | Int64(targetAddress >> 16 & 0xffff) << 5) << 32
             originalFunctionPointer8.pointee =
-                (0xf2c00008 | UInt64(targetAddress >> 32 & 0xffff) << 5) |
-                (0xf2e00008 | UInt64(targetAddress >> 48 & 0xffff) << 5) << 32
+                (0xf2c00008 | Int64(targetAddress >> 32 & 0xffff) << 5) |
+                (0xf2e00008 | Int64(targetAddress >> 48 & 0xffff) << 5) << 32
             originalFunctionPointer16.pointee = 0xd61f0100
 
             #elseif arch(x86_64)

--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -72,6 +72,8 @@ class CFunctionInjector {
         reset()
     }
     
+    /// Disable EXEC and write TEXT segment memory, then enable EXEC again.
+    /// Ref: https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon
     private func writeText(_ writer: () -> Void) {
         var status = mprotect(textRange.start, textRange.size, PROT_READ | PROT_WRITE)
         if status == -1 {

--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -72,7 +72,7 @@ class CFunctionInjector {
     }
     
     deinit {
-        try! reset()
+        reset()
     }
     
     /// Disable EXEC and write TEXT segment memory, then enable EXEC again.
@@ -94,9 +94,9 @@ class CFunctionInjector {
     /// 
     /// - Parameters:
     ///   - destination: c function pointer.
-    func inject(_ destination: UnsafeRawPointer) throws {
+    func inject(_ destination: UnsafeRawPointer) {
         assert(Thread.isMainThread)
-        try writeText {
+        try! writeText {
             // Set the first instruction of the original function to be a jump to the replacement function.
 
             let targetAddress = Int64(Int(bitPattern: destination))
@@ -134,9 +134,9 @@ class CFunctionInjector {
     /// Ref: https://github.com/thomasfinch/CRuntimeFunctionHooker/blob/master/inject.c
     ///
     /// - Parameter symbol: c function name.
-    func reset() throws {
+    func reset() {
         assert(Thread.isMainThread)
-        try writeText {
+        try! writeText {
             originalFunctionPointer0.pointee = escapedInstructionBytes0
             originalFunctionPointer8.pointee = escapedInstructionBytes8
             originalFunctionPointer16.pointee = escapedInstructionBytes16

--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import libkern
 
 class CFunctionInjector {
     struct Error : LocalizedError, CustomStringConvertible {
@@ -81,6 +82,7 @@ class CFunctionInjector {
         if status == -1 {
             fatalError("failed to add exec flag to memory protection: errno=\(errno)")
         }
+        sys_icache_invalidate(textRange.start, textRange.size)
     }
     /// Inject c function to c function.
     /// Ref: https://github.com/thomasfinch/CRuntimeFunctionHooker/blob/master/inject.c

--- a/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
+++ b/Sources/XCTAssertAutolayout/Core/CFunctionInjector.swift
@@ -56,7 +56,7 @@ class CFunctionInjector {
         }
         
         let start = Int(bitPattern: target)
-        let end = start + 3
+        let end = start + 3 * 8
         let pageStart = start & -pageSize
         let size = end - pageStart
         self.textRange = (UnsafeMutableRawPointer(bitPattern: pageStart), size)


### PR DESCRIPTION
1. Apple Silicon doesn't allow to have `PROT_WRITE | PROT_EXEC` at the same time, so enable `PROT_WRITE` and disable `PROT_EXEC` during replacement.
2. Every writing instruction, it's always necessary to call `sys_icache_invalidate` to invalidate the instruction cache to avoid re-using old instructions.

I tested this patch on my local M1 Mac mini and it passed the all test suites.

<img width="737" alt="Screen Shot 2021-07-13 at 2 08 25" src="https://user-images.githubusercontent.com/11702759/125328443-4604bf00-e37f-11eb-9655-9708bf5f9080.png">


Reference: https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon